### PR TITLE
chore: fixed package.json dependencies list issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,26 @@
 {
   "name": "remark-typescript-code-import",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remark-typescript-code-import",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "mdast": "^3.0.0",
+        "typescript": "^5.3.3",
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.5",
-        "mdast": "^3.0.0",
         "mdast-util-directive": "^3.0.0",
         "mdast-util-mdx-jsx": "^3.0.0",
         "prettier": "3.2.4",
         "remark": "^15.0.1",
         "remark-directive": "^3.0.0",
         "rimraf": "^5.0.5",
-        "typescript": "^5.3.3",
         "vfile": "^6.0.1",
         "vitest": "^1.2.2"
       },
@@ -1357,8 +1357,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mdast/-/mdast-3.0.0.tgz",
       "integrity": "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==",
-      "deprecated": "`mdast` was renamed to `remark`",
-      "dev": true
+      "deprecated": "`mdast` was renamed to `remark`"
     },
     "node_modules/mdast-util-directive": {
       "version": "3.0.0",
@@ -2584,7 +2583,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3837,8 +3835,7 @@
     "mdast": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mdast/-/mdast-3.0.0.tgz",
-      "integrity": "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==",
-      "dev": true
+      "integrity": "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="
     },
     "mdast-util-directive": {
       "version": "3.0.0",
@@ -4629,8 +4626,7 @@
     "typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
     },
     "ufo": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -36,18 +36,18 @@
     "watch": "npm run build -- --watch"
   },
   "dependencies": {
+    "mdast": "^3.0.0",
+    "typescript": "^5.3.3",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",
-    "mdast": "^3.0.0",
     "mdast-util-directive": "^3.0.0",
     "mdast-util-mdx-jsx": "^3.0.0",
     "prettier": "3.2.4",
     "remark": "^15.0.1",
     "remark-directive": "^3.0.0",
     "rimraf": "^5.0.5",
-    "typescript": "^5.3.3",
     "vfile": "^6.0.1",
     "vitest": "^1.2.2"
   }


### PR DESCRIPTION
`mast` and `typescript` were tagged dev-dependencies. However, they are dependencies.