### PR TITLE
fix: naming convention fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,8 @@ It supports multiple files and types
 ## Options
 
 - `directiveName: string`: The directive name. Defaults to `component-docs`.
-- `fileAttrName: string`: The attribute name for file path. Defaults to `file`.
+- `fileAttributeName: string`: The attribute name for file path. Defaults to `file`.
 - `rootDir: string`: Change what `<rootDir>` refers to. Defaults to `process.cwd()`.
-- `reactDocGenOptions: object`: Options for [`react-docgen-typescript`](https://github.com/styleguidist/react-docgen-typescript?tab=readme-ov-file#options).
 
 ## Testing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as ts from 'typescript';
 
 export type PluginOptions = {
   directiveName?: string;
-  fileAttrName?: string;
+  fileAttributeName?: string;
   rootDir?: string;
 };
 
@@ -64,7 +64,7 @@ function extract(file: string, identifiers: string[]) {
 
 const plugin = ({
   directiveName = 'typescript',
-  fileAttrName = 'file',
+  fileAttributeName = 'file',
   rootDir = process.cwd(),
 }: PluginOptions = {}) => {
   return async (tree: Root, vfile: any) => {
@@ -100,12 +100,12 @@ const plugin = ({
         }
 
         const attributes = node.attributes || {};
-        const { [fileAttrName]: fileMetadata, ...restAttrs } = attributes;
+        const { [fileAttributeName]: fileMetadata, ...restAttrs } = attributes;
 
         if (!fileMetadata) {
           vfile.fail(
             `
-            ${directiveName} directive must have ${fileAttrName} attribute.
+            ${directiveName} directive must have ${fileAttributeName} attribute.
             
             ${getHelpersText({ directiveName })}
             `,

--- a/test/index.test.mts
+++ b/test/index.test.mts
@@ -121,7 +121,7 @@ test('Used Options', async () => {
     .use(remarkDirectivePlugin)
     .use(remarkTypescriptCodeImport, {
       directiveName: 'type',
-      fileAttrName: 'filePath',
+      fileAttributeName: 'filePath',
       rootDir: `${cwd}/src`,
     })
     .process(inputData);


### PR DESCRIPTION
Renamed `fileAttrName` to `fileAttributeName` for better clarity on API.

- [x] Test passes